### PR TITLE
feat: boosted creatures and event schedule

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
+SERVER_PATH=C:/canary
 MYSQL_DBNAME=canary
 MYSQL_HOST=localhost
 MYSQL_PORT=3306
@@ -12,5 +13,4 @@ RATE_LIMITER_RATE=2
 SERVER_IP=127.0.0.1
 SERVER_NAME=Canary
 SERVER_PORT=7172
-VOCATIONS=Engineer,Doctor,Magician,Runner,Teacher,Coder,Business Man,Writer,Youtuber
 SERVER_LOCATION=BRA

--- a/src/api/api.go
+++ b/src/api/api.go
@@ -3,6 +3,9 @@ package api
 import (
 	"database/sql"
 	"errors"
+	"net/http"
+	"sync"
+
 	"github.com/gin-gonic/gin"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/opentibiabr/login-server/src/api/limiter"
@@ -11,8 +14,6 @@ import (
 	"github.com/opentibiabr/login-server/src/logger"
 	"github.com/opentibiabr/login-server/src/server"
 	"google.golang.org/grpc"
-	"net/http"
-	"sync"
 )
 
 type Api struct {
@@ -20,6 +21,9 @@ type Api struct {
 	DB             *sql.DB
 	GrpcConnection *grpc.ClientConn
 	server.ServerInterface
+	BoostedCreatureID uint32
+	BoostedBossID     uint32
+	ServerPath        string
 }
 
 func Initialize(gConfigs configs.GlobalConfigs) *Api {
@@ -41,6 +45,7 @@ func Initialize(gConfigs configs.GlobalConfigs) *Api {
 	_api.Router.Use(logger.LogRequest())
 	_api.Router.Use(gin.Recovery())
 	_api.Router.Use(ipLimiter.Limit())
+	_api.ServerPath = configs.GetEnvStr("SERVER_PATH", "")
 
 	_api.initializeRoutes()
 

--- a/src/api/api.go
+++ b/src/api/api.go
@@ -24,6 +24,7 @@ type Api struct {
 	BoostedCreatureID uint32
 	BoostedBossID     uint32
 	ServerPath        string
+	CorePath          string
 }
 
 func Initialize(gConfigs configs.GlobalConfigs) *Api {
@@ -46,6 +47,7 @@ func Initialize(gConfigs configs.GlobalConfigs) *Api {
 	_api.Router.Use(gin.Recovery())
 	_api.Router.Use(ipLimiter.Limit())
 	_api.ServerPath = configs.GetEnvStr("SERVER_PATH", "")
+	_api.CorePath = _api.ServerPath + "/data/"
 
 	_api.initializeRoutes()
 
@@ -53,7 +55,7 @@ func Initialize(gConfigs configs.GlobalConfigs) *Api {
 
 	_api.GrpcConnection, err = grpc.Dial(gConfigs.LoginServerConfigs.Grpc.Format(), grpc.WithInsecure())
 	if err != nil {
-		logger.Error(errors.New("Couldn't start GRPC reverse proxy."))
+		logger.Error(errors.New("couldn't start GRPC reverse proxy server, check if the login server is running and the GRPC port is open"))
 	}
 
 	return &_api

--- a/src/api/login.go
+++ b/src/api/login.go
@@ -19,7 +19,7 @@ func (_api *Api) login(c *gin.Context) {
 
 	switch payload.Type {
 	case "eventschedule":
-		database.HandleEventSchedule(c, _api.ServerPath+"/data/XML/events.xml")
+		database.HandleEventSchedule(c, _api.CorePath+"XML/events.xml")
 	case "boostedcreature":
 		database.HandleBoostedCreature(c, _api.DB, &_api.BoostedCreatureID, &_api.BoostedBossID)
 	case "login":

--- a/src/api/login.go
+++ b/src/api/login.go
@@ -2,11 +2,12 @@ package api
 
 import (
 	"context"
-	"github.com/gin-gonic/gin"
-	_ "github.com/go-sql-driver/mysql"
-	"github.com/opentibiabr/login-server/src/api/models"
-	"github.com/opentibiabr/login-server/src/grpc/login_proto_messages"
 	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/opentibiabr/login-server/src/api/models"
+	"github.com/opentibiabr/login-server/src/database"
+	"github.com/opentibiabr/login-server/src/grpc/login_proto_messages"
 )
 
 func (_api *Api) login(c *gin.Context) {
@@ -16,29 +17,33 @@ func (_api *Api) login(c *gin.Context) {
 		return
 	}
 
-	if payload.Type != "login" {
+	switch payload.Type {
+	case "eventschedule":
+		database.HandleEventSchedule(c, _api.ServerPath+"/data/XML/events.xml")
+	case "boostedcreature":
+		database.HandleBoostedCreature(c, _api.DB, &_api.BoostedCreatureID, &_api.BoostedBossID)
+	case "login":
+		grpcClient := login_proto_messages.NewLoginServiceClient(_api.GrpcConnection)
+
+		res, err := grpcClient.Login(
+			context.Background(),
+			&login_proto_messages.LoginRequest{Email: payload.Email, Password: payload.Password},
+		)
+
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		if res.GetError() != nil {
+			c.JSON(http.StatusOK, buildErrorPayloadFromMessage(res))
+			return
+		}
+
+		c.JSON(http.StatusOK, buildPayloadFromMessage(res))
+	default:
 		c.JSON(http.StatusNotImplemented, gin.H{"status": "not implemented"})
-		return
 	}
-
-	grpcClient := login_proto_messages.NewLoginServiceClient(_api.GrpcConnection)
-
-	res, err := grpcClient.Login(
-		context.Background(),
-		&login_proto_messages.LoginRequest{Email: payload.Email, Password: payload.Password},
-	)
-
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-
-	if res.GetError() != nil {
-		c.JSON(http.StatusOK, buildErrorPayloadFromMessage(res))
-		return
-	}
-
-	c.JSON(http.StatusOK, buildPayloadFromMessage(res))
 }
 
 func buildPayloadFromMessage(msg *login_proto_messages.LoginResponse) models.ResponsePayload {

--- a/src/configs/configs.go
+++ b/src/configs/configs.go
@@ -1,10 +1,13 @@
 package configs
 
 import (
+	"bufio"
+	"os"
+	"regexp"
+	"strconv"
+
 	"github.com/joho/godotenv"
 	"github.com/opentibiabr/login-server/src/logger"
-	"os"
-	"strconv"
 )
 
 type Config interface {
@@ -15,6 +18,10 @@ type GlobalConfigs struct {
 	DBConfigs          DBConfigs
 	GameServerConfigs  GameServerConfigs
 	LoginServerConfigs LoginServerConfigs
+}
+
+type LuaConfigManager struct {
+	configs map[string]string
 }
 
 // Init only works for variables that are not yet defined. /*
@@ -57,5 +64,85 @@ func GetEnvStr(key string, defaultValue ...string) string {
 		return defaultValue[0]
 	}
 
+	return value
+}
+
+func (manager *LuaConfigManager) loadConfigs(filePath string) error {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	re := regexp.MustCompile(`^(\w+)\s*=\s*(["']?.*["']?)$`)
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		matches := re.FindStringSubmatch(line)
+		if len(matches) == 3 {
+			manager.configs[matches[1]] = matches[2]
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// NewLuaConfigManager creates a new instance of LuaConfigManager by loading configurations from the specified Lua file.
+// It returns the LuaConfigManager instance and any error encountered during the file loading process.
+func NewLuaConfigManager(filePath string) (*LuaConfigManager, error) {
+	manager := &LuaConfigManager{
+		configs: make(map[string]string),
+	}
+	err := manager.loadConfigs(filePath)
+	if err != nil {
+		return nil, err
+	}
+	return manager, nil
+}
+
+// GetString retrieves the string value for a given key from the configuration.
+// If the key does not exist or the value is not a string, it returns an empty string.
+func (manager *LuaConfigManager) GetString(key string) string {
+	value, exists := manager.configs[key]
+	if !exists {
+		return ""
+	}
+
+	if exists && len(value) > 1 && (value[0] == '"' || value[0] == '\'') && value[0] == value[len(value)-1] {
+		value = value[1 : len(value)-1]
+	}
+	return value
+}
+
+// GetInt retrieves the integer value for a given key from the configuration.
+// It returns 0 if the key does not exist, the value is not an integer, or an error occurs during conversion.
+func (manager *LuaConfigManager) GetInt(key string) int {
+	valueStr := manager.GetString(key)
+	if valueStr == "" {
+		return 0
+	}
+	value, err := strconv.Atoi(valueStr)
+	if err != nil {
+		return 0
+	}
+	return value
+}
+
+// GetBool retrieves the boolean value for a given key from the configuration.
+// It returns false if the key does not exist, the value is not a boolean, or an error occurs during conversion.
+func (manager *LuaConfigManager) GetBool(key string) bool {
+	valueStr := manager.GetString(key)
+	if valueStr == "" {
+		return false
+	}
+	value, err := strconv.ParseBool(valueStr)
+	if err != nil {
+		return false
+	}
 	return value
 }

--- a/src/configs/configs.go
+++ b/src/configs/configs.go
@@ -20,6 +20,8 @@ type GlobalConfigs struct {
 	LoginServerConfigs LoginServerConfigs
 }
 
+// LuaConfigManager is a structure that manages configurations loaded from a Lua file.
+// It stores the configurations as key-value pairs, where both keys and values are strings.
 type LuaConfigManager struct {
 	configs map[string]string
 }

--- a/src/database/creature_boost.go
+++ b/src/database/creature_boost.go
@@ -1,3 +1,7 @@
+// Package database provides functionalities for interacting with the database of the system,
+// including operations to fetch and update data about boosted creatures and bosses. This package
+// encapsulates all SQL queries and data manipulations, making maintenance and future development
+// easier.
 package database
 
 import (
@@ -44,6 +48,12 @@ func checkAndUpdateBoostedCreatureData(db *sql.DB, creatureRaceID *uint32, bossR
 	return nil
 }
 
+// HandleBoostedCreature checks for updated boosted creature and boss race IDs in the database,
+// updates the provided race IDs if they are different, and responds with the current boosted creature
+// and boss race IDs. It takes a Gin context, a database connection, and pointers to the creature and boss
+// race IDs as arguments. If there is an error in checking or updating the boosted creature data,
+// it responds with an internal server error. Otherwise, it responds with a JSON containing the
+// boosted creature status and the current race IDs for the creature and boss.
 func HandleBoostedCreature(c *gin.Context, db *sql.DB, creatureRaceID *uint32, bossRaceID *uint32) {
 	if err := checkAndUpdateBoostedCreatureData(db, creatureRaceID, bossRaceID); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})

--- a/src/database/creature_boost.go
+++ b/src/database/creature_boost.go
@@ -1,0 +1,58 @@
+package database
+
+import (
+	"database/sql"
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/opentibiabr/login-server/src/logger"
+)
+
+func loadBoostedCreatureData(db *sql.DB) (uint32, uint32, error) {
+	var creatureRaceID uint32
+	var bossRaceID uint32
+
+	query := "SELECT raceid FROM boosted_creature LIMIT 1"
+	err := db.QueryRow(query).Scan(&creatureRaceID)
+	if err != nil {
+		logger.Debug(fmt.Sprintf("Failed to load boosted creature data: %s", err.Error()))
+		return 0, 0, err
+	}
+
+	query = "SELECT raceid FROM boosted_boss LIMIT 1"
+	err = db.QueryRow(query).Scan(&bossRaceID)
+	if err != nil {
+		logger.Debug(fmt.Sprintf("Failed to load boosted boss data: %s", err.Error()))
+		return 0, 0, err
+	}
+
+	return creatureRaceID, bossRaceID, nil
+}
+
+func checkAndUpdateBoostedCreatureData(db *sql.DB, creatureRaceID *uint32, bossRaceID *uint32) error {
+	currentCreatureID, currentBossID, err := loadBoostedCreatureData(db)
+	if err != nil {
+		return err
+	}
+
+	if *creatureRaceID != currentCreatureID || *bossRaceID != currentBossID {
+		logger.Info(fmt.Sprintf("Updating creatureid: '%d', bossid: '%d' due to change detected", currentCreatureID, currentBossID))
+		*creatureRaceID = currentCreatureID
+		*bossRaceID = currentBossID
+	}
+	return nil
+}
+
+func HandleBoostedCreature(c *gin.Context, db *sql.DB, creatureRaceID *uint32, bossRaceID *uint32) {
+	if err := checkAndUpdateBoostedCreatureData(db, creatureRaceID, bossRaceID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"boostedcreature": true,
+		"creatureraceid":  creatureRaceID,
+		"bossraceid":      bossRaceID,
+	})
+}

--- a/src/database/event_scheduler.go
+++ b/src/database/event_scheduler.go
@@ -1,3 +1,7 @@
+// Package database provides functionalities for interacting with the database of the system,
+// including operations to fetch and update data about boosted creatures and bosses. This package
+// encapsulates all SQL queries and data manipulations, making maintenance and future development
+// easier.
 package database
 
 import (
@@ -13,36 +17,36 @@ import (
 	"github.com/opentibiabr/login-server/src/logger"
 )
 
-type Events struct {
+type events struct {
 	XMLName xml.Name `xml:"events"`
-	Events  []Event  `xml:"event"`
+	Events  []event  `xml:"event"`
 }
 
-type Description struct {
+type description struct {
 	Text string `xml:"description,attr"`
 }
 
-type Event struct {
+type event struct {
 	Name        string      `xml:"name,attr"`
 	StartDate   string      `xml:"startdate,attr"`
 	EndDate     string      `xml:"enddate,attr"`
-	Colors      Colors      `xml:"colors"`
-	Description Description `xml:"description"`
-	Details     Details     `xml:"details"`
+	Colors      colors      `xml:"colors"`
+	Description description `xml:"description"`
+	Details     details     `xml:"details"`
 }
 
-type Colors struct {
+type colors struct {
 	Light string `xml:"colorlight,attr"`
 	Dark  string `xml:"colordark,attr"`
 }
 
-type Details struct {
+type details struct {
 	DisplayPriority string `xml:"displaypriority,attr"`
 	IsSeasonal      string `xml:"isseasonal,attr"`
 	SpecialEvent    string `xml:"specialevent,attr"`
 }
 
-func loadEventsSchedule(filePath string) (*Events, error) {
+func loadEventsSchedule(filePath string) (*events, error) {
 	xmlFile, err := os.Open(filePath)
 	if err != nil {
 		logger.Error(fmt.Errorf(err.Error()))
@@ -56,7 +60,7 @@ func loadEventsSchedule(filePath string) (*Events, error) {
 		return nil, err
 	}
 
-	var events Events
+	var events events
 	err = xml.Unmarshal(byteValue, &events)
 	if err != nil {
 		logger.Error(fmt.Errorf(err.Error()))
@@ -81,7 +85,7 @@ func parseDateString(dateStr string) int {
 	return 0
 }
 
-func processEvents(events *Events) []map[string]interface{} {
+func processEvents(events *events) []map[string]interface{} {
 	eventList := make([]map[string]interface{}, 0)
 
 	for _, event := range events.Events {
@@ -111,6 +115,11 @@ func processEvents(events *Events) []map[string]interface{} {
 	return eventList
 }
 
+// HandleEventSchedule loads and processes an event schedule from a specified XML file.
+// It takes a Gin context and a string path to the event XML file as arguments.
+// If the event schedule is loaded and processed successfully, it sends back a JSON response
+// with the list of events and the last update timestamp.
+// If there is an error loading or processing the event schedule, it responds with an internal server error.
 func HandleEventSchedule(c *gin.Context, eventPath string) {
 	events, err := loadEventsSchedule(eventPath)
 	if err != nil {

--- a/src/database/event_scheduler.go
+++ b/src/database/event_scheduler.go
@@ -1,0 +1,126 @@
+package database
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/opentibiabr/login-server/src/logger"
+)
+
+type Events struct {
+	XMLName xml.Name `xml:"events"`
+	Events  []Event  `xml:"event"`
+}
+
+type Description struct {
+	Text string `xml:"description,attr"`
+}
+
+type Event struct {
+	Name        string      `xml:"name,attr"`
+	StartDate   string      `xml:"startdate,attr"`
+	EndDate     string      `xml:"enddate,attr"`
+	Colors      Colors      `xml:"colors"`
+	Description Description `xml:"description"`
+	Details     Details     `xml:"details"`
+}
+
+type Colors struct {
+	Light string `xml:"colorlight,attr"`
+	Dark  string `xml:"colordark,attr"`
+}
+
+type Details struct {
+	DisplayPriority string `xml:"displaypriority,attr"`
+	IsSeasonal      string `xml:"isseasonal,attr"`
+	SpecialEvent    string `xml:"specialevent,attr"`
+}
+
+func loadEventsSchedule(filePath string) (*Events, error) {
+	xmlFile, err := os.Open(filePath)
+	if err != nil {
+		logger.Error(fmt.Errorf(err.Error()))
+		return nil, err
+	}
+	defer xmlFile.Close()
+
+	byteValue, err := io.ReadAll(xmlFile)
+	if err != nil {
+		logger.Error(fmt.Errorf(err.Error()))
+		return nil, err
+	}
+
+	var events Events
+	err = xml.Unmarshal(byteValue, &events)
+	if err != nil {
+		logger.Error(fmt.Errorf(err.Error()))
+		return nil, err
+	}
+
+	logger.Debug(fmt.Sprintf("Unmarshal from XML done successfully, %d events loaded.", len(events.Events)))
+	return &events, nil
+}
+
+func parseDateString(dateStr string) int {
+	layouts := []string{"02/01/2006", "2/01/2006", "02/1/2006", "2/1/2006"}
+	var t time.Time
+	var err error
+	for _, layout := range layouts {
+		t, err = time.ParseInLocation(layout, dateStr, time.Local)
+		if err == nil {
+			return int(t.Unix())
+		}
+	}
+	logger.Error(fmt.Errorf(err.Error()))
+	return 0
+}
+
+func processEvents(events *Events) []map[string]interface{} {
+	eventList := make([]map[string]interface{}, 0)
+
+	for _, event := range events.Events {
+		displayPriority, _ := strconv.Atoi(event.Details.DisplayPriority)
+		isSeasonal, err := strconv.ParseBool(event.Details.IsSeasonal)
+		if err != nil {
+			isSeasonal = false
+		}
+		specialEvent, err := strconv.ParseBool(event.Details.SpecialEvent)
+		if err != nil {
+			specialEvent = false
+		}
+		eventMap := map[string]interface{}{
+			"colorlight":      event.Colors.Light,
+			"colordark":       event.Colors.Dark,
+			"description":     event.Description.Text,
+			"displaypriority": displayPriority,
+			"enddate":         parseDateString(event.EndDate),
+			"isseasonal":      isSeasonal,
+			"name":            event.Name,
+			"startdate":       parseDateString(event.StartDate),
+			"specialevent":    specialEvent,
+		}
+		eventList = append(eventList, eventMap)
+	}
+
+	return eventList
+}
+
+func HandleEventSchedule(c *gin.Context, eventPath string) {
+	events, err := loadEventsSchedule(eventPath)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err})
+		return
+	}
+
+	eventList := processEvents(events)
+	c.JSON(http.StatusOK, gin.H{
+		"eventlist":           eventList,
+		"lastupdatetimestamp": time.Now().Unix(),
+	})
+}

--- a/src/logger/logger.go
+++ b/src/logger/logger.go
@@ -2,10 +2,11 @@ package logger
 
 import (
 	"fmt"
+	"time"
+
 	nested "github.com/antonfisher/nested-logrus-formatter"
 	"github.com/gin-gonic/gin"
 	log "github.com/sirupsen/logrus"
-	"time"
 )
 
 var logger = log.New()


### PR DESCRIPTION
Added features for read boosted creature/boss and event scheduler.
New env "SERVER_PATH" for reading the "events.xml"
Removed "VOCATIONS" env by default, already read the standard vocations
Functions for read "config.lua" variables (bool, string, int), this will allow us to access the variables to use if necessary