### PR TITLE
feat: add livestream login flow

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	bou.ke/monkey v1.0.2
+	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/antonfisher/nested-logrus-formatter v1.3.1
 	github.com/gin-contrib/cors v1.7.2 // indirect
 	github.com/gin-gonic/gin v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ bou.ke/monkey v1.0.2 h1:kWcnsrCNUatbxncxR/ThdYqbytgOIArtYWqcQLQzKLI=
 bou.ke/monkey v1.0.2/go.mod h1:OqickVX3tNx6t33n1xvtTtu85YN5s6cKwVug+oHMaIA=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/antonfisher/nested-logrus-formatter v1.3.1 h1:NFJIr+pzwv5QLHTPyKz9UMEoHck02Q9L0FP13b/xSbQ=
 github.com/antonfisher/nested-logrus-formatter v1.3.1/go.mod h1:6WTfyWFkBc9+zyBaKIqRrg/KwMqBbodBjgbHjDz7zjA=
 github.com/bytedance/sonic v1.5.0/go.mod h1:ED5hyg4y6t3/9Ku1R6dU/4KyJ48DZ4jPhfY1O2AihPM=
@@ -90,6 +92,7 @@ github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGn
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.2.4/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
 github.com/klauspost/cpuid/v2 v2.2.7 h1:ZWSB3igEs+d0qvnxR/ZBzXVmxkgt8DdzP6m9pfuVLDM=

--- a/src/database/livestream.go
+++ b/src/database/livestream.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -12,6 +13,7 @@ import (
 )
 
 const LivestreamSessionAccount = "@livestream"
+const LivestreamStatusActive = 1
 
 var ErrLivestreamCastersUnavailable = errors.New("active livestream caster table unavailable")
 
@@ -20,7 +22,7 @@ func IsLivestreamLogin(email string) bool {
 	return email == LivestreamSessionAccount || email == "@livesteam"
 }
 
-func LoadLivestreamCasters(db *sql.DB) ([]*login_proto_messages.Character, error) {
+func LoadLivestreamCasters(ctx context.Context, db *sql.DB) ([]*login_proto_messages.Character, error) {
 	const query = `
 		SELECT p.name, p.level, p.sex, p.vocation, p.looktype, p.lookhead, p.lookbody,
 			p.looklegs, p.lookfeet, p.lookaddons, p.lastlogin
@@ -29,7 +31,7 @@ func LoadLivestreamCasters(db *sql.DB) ([]*login_proto_messages.Character, error
 		WHERE lc.livestream_status >= ?
 		ORDER BY lc.livestream_viewers DESC, p.name ASC`
 
-	rows, err := db.Query(query, 1)
+	rows, err := db.QueryContext(ctx, query, LivestreamStatusActive)
 	if err != nil {
 		if isMissingLivestreamCastersTable(err) {
 			return nil, fmt.Errorf("%w: %v", ErrLivestreamCastersUnavailable, err)
@@ -57,7 +59,7 @@ func LoadLivestreamCasters(db *sql.DB) ([]*login_proto_messages.Character, error
 			return nil, err
 		}
 
-		if vocation < len(vocations) {
+		if vocation >= 0 && vocation < len(vocations) {
 			caster.Info.Vocation = vocations[vocation]
 		}
 

--- a/src/database/livestream.go
+++ b/src/database/livestream.go
@@ -1,0 +1,82 @@
+package database
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	mysqlDriver "github.com/go-sql-driver/mysql"
+	"github.com/opentibiabr/login-server/src/configs"
+	"github.com/opentibiabr/login-server/src/grpc/login_proto_messages"
+)
+
+const LivestreamSessionAccount = "@livestream"
+
+var ErrLivestreamCastersUnavailable = errors.New("active livestream caster table unavailable")
+
+func IsLivestreamLogin(email string) bool {
+	email = strings.ToLower(strings.TrimSpace(email))
+	return email == LivestreamSessionAccount || email == "@livesteam"
+}
+
+func LoadLivestreamCasters(db *sql.DB) ([]*login_proto_messages.Character, error) {
+	const query = `
+		SELECT p.name, p.level, p.sex, p.vocation, p.looktype, p.lookhead, p.lookbody,
+			p.looklegs, p.lookfeet, p.lookaddons, p.lastlogin
+		FROM players p
+		INNER JOIN active_livestream_casters lc ON p.id = lc.caster_id
+		WHERE lc.livestream_status >= ?
+		ORDER BY lc.livestream_viewers DESC, p.name ASC`
+
+	rows, err := db.Query(query, 1)
+	if err != nil {
+		if isMissingLivestreamCastersTable(err) {
+			return nil, fmt.Errorf("%w: %v", ErrLivestreamCastersUnavailable, err)
+		}
+		return nil, err
+	}
+	defer rows.Close()
+
+	vocations := configs.GetServerVocations()
+	casters := make([]*login_proto_messages.Character, 0)
+	for rows.Next() {
+		caster := login_proto_messages.Character{
+			WorldId: 0,
+			Info:    &login_proto_messages.CharacterInfo{},
+			Outfit:  &login_proto_messages.CharacterOutfit{},
+		}
+
+		var vocation int
+		if err := rows.Scan(
+			&caster.Info.Name, &caster.Info.Level, &caster.Info.Sex, &vocation,
+			&caster.Outfit.LookType, &caster.Outfit.LookHead, &caster.Outfit.LookBody,
+			&caster.Outfit.LookLegs, &caster.Outfit.LookFeet, &caster.Outfit.Addons,
+			&caster.Info.LastLogin,
+		); err != nil {
+			return nil, err
+		}
+
+		if vocation < len(vocations) {
+			caster.Info.Vocation = vocations[vocation]
+		}
+
+		casters = append(casters, &caster)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return casters, nil
+}
+
+func isMissingLivestreamCastersTable(err error) bool {
+	var mysqlErr *mysqlDriver.MySQLError
+	if errors.As(err, &mysqlErr) {
+		return mysqlErr.Number == 1146 && strings.Contains(strings.ToLower(mysqlErr.Message), "active_livestream_casters")
+	}
+
+	lowered := strings.ToLower(err.Error())
+	return strings.Contains(lowered, "active_livestream_casters") && strings.Contains(lowered, "doesn't exist")
+}

--- a/src/database/livestream.go
+++ b/src/database/livestream.go
@@ -19,7 +19,7 @@ var ErrLivestreamCastersUnavailable = errors.New("active livestream caster table
 
 func IsLivestreamLogin(email string) bool {
 	email = strings.ToLower(strings.TrimSpace(email))
-	return email == LivestreamSessionAccount || email == "@livesteam"
+	return email == LivestreamSessionAccount
 }
 
 func LoadLivestreamCasters(ctx context.Context, db *sql.DB) ([]*login_proto_messages.Character, error) {

--- a/src/database/livestream_test.go
+++ b/src/database/livestream_test.go
@@ -18,9 +18,8 @@ func TestIsLivestreamLogin(t *testing.T) {
 	}{
 		{name: "canonical", email: "@livestream", want: true},
 		{name: "canonical with spaces and case", email: " @LiveStream ", want: true},
-		{name: "accepted typo", email: "@livesteam", want: true},
+		{name: "plain descriptor", email: "livestream", want: false},
 		{name: "empty", email: "", want: false},
-		{name: "typo as regular email", email: "user@LiveSteam.com", want: false},
 		{name: "livestream substring", email: "user@livestream2.com", want: false},
 		{name: "regular account", email: "player@example.com", want: false},
 	}

--- a/src/database/livestream_test.go
+++ b/src/database/livestream_test.go
@@ -1,9 +1,11 @@
 package database
 
 import (
+	"context"
 	"errors"
 	"testing"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	mysqlDriver "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
 )
@@ -17,6 +19,9 @@ func TestIsLivestreamLogin(t *testing.T) {
 		{name: "canonical", email: "@livestream", want: true},
 		{name: "canonical with spaces and case", email: " @LiveStream ", want: true},
 		{name: "accepted typo", email: "@livesteam", want: true},
+		{name: "empty", email: "", want: false},
+		{name: "typo as regular email", email: "user@LiveSteam.com", want: false},
+		{name: "livestream substring", email: "user@livestream2.com", want: false},
 		{name: "regular account", email: "player@example.com", want: false},
 	}
 
@@ -32,7 +37,68 @@ func TestIsMissingLivestreamCastersTable(t *testing.T) {
 		Number:  1146,
 		Message: "Table 'otserv.active_livestream_casters' doesn't exist",
 	}))
+	assert.False(t, isMissingLivestreamCastersTable(&mysqlDriver.MySQLError{
+		Number:  1146,
+		Message: "Table 'otserv.players' doesn't exist",
+	}))
 	assert.True(t, isMissingLivestreamCastersTable(errors.New("table `active_livestream_casters` doesn't exist")))
 	assert.False(t, isMissingLivestreamCastersTable(errors.New("table `players` doesn't exist")))
 	assert.False(t, isMissingLivestreamCastersTable(errors.New("connection refused")))
+}
+
+func TestLoadLivestreamCasters(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer db.Close()
+
+	rows := sqlmock.NewRows(livestreamCasterColumns()).
+		AddRow("Alice", uint32(100), uint32(1), 3, uint32(128), uint32(10), uint32(20), uint32(30), uint32(40), uint32(0), uint32(123)).
+		AddRow("Invalid Vocation", uint32(50), uint32(0), -1, uint32(129), uint32(1), uint32(2), uint32(3), uint32(4), uint32(0), uint32(456))
+	mock.ExpectQuery("SELECT p.name").
+		WithArgs(LivestreamStatusActive).
+		WillReturnRows(rows)
+
+	casters, err := LoadLivestreamCasters(context.Background(), db)
+	assert.NoError(t, err)
+	assert.Len(t, casters, 2)
+	assert.Equal(t, "Alice", casters[0].Info.Name)
+	assert.Equal(t, uint32(100), casters[0].Info.Level)
+	assert.Equal(t, "Paladin", casters[0].Info.Vocation)
+	assert.Equal(t, "Invalid Vocation", casters[1].Info.Name)
+	assert.Empty(t, casters[1].Info.Vocation)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestLoadLivestreamCastersWrapsMissingTable(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT p.name").
+		WithArgs(LivestreamStatusActive).
+		WillReturnError(&mysqlDriver.MySQLError{
+			Number:  1146,
+			Message: "Table 'otserv.active_livestream_casters' doesn't exist",
+		})
+
+	casters, err := LoadLivestreamCasters(context.Background(), db)
+	assert.Nil(t, casters)
+	assert.ErrorIs(t, err, ErrLivestreamCastersUnavailable)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func livestreamCasterColumns() []string {
+	return []string{
+		"name",
+		"level",
+		"sex",
+		"vocation",
+		"looktype",
+		"lookhead",
+		"lookbody",
+		"looklegs",
+		"lookfeet",
+		"lookaddons",
+		"lastlogin",
+	}
 }

--- a/src/database/livestream_test.go
+++ b/src/database/livestream_test.go
@@ -1,0 +1,38 @@
+package database
+
+import (
+	"errors"
+	"testing"
+
+	mysqlDriver "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsLivestreamLogin(t *testing.T) {
+	tests := []struct {
+		name  string
+		email string
+		want  bool
+	}{
+		{name: "canonical", email: "@livestream", want: true},
+		{name: "canonical with spaces and case", email: " @LiveStream ", want: true},
+		{name: "accepted typo", email: "@livesteam", want: true},
+		{name: "regular account", email: "player@example.com", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsLivestreamLogin(tt.email))
+		})
+	}
+}
+
+func TestIsMissingLivestreamCastersTable(t *testing.T) {
+	assert.True(t, isMissingLivestreamCastersTable(&mysqlDriver.MySQLError{
+		Number:  1146,
+		Message: "Table 'otserv.active_livestream_casters' doesn't exist",
+	}))
+	assert.True(t, isMissingLivestreamCastersTable(errors.New("table `active_livestream_casters` doesn't exist")))
+	assert.False(t, isMissingLivestreamCastersTable(errors.New("table `players` doesn't exist")))
+	assert.False(t, isMissingLivestreamCastersTable(errors.New("connection refused")))
+}

--- a/src/grpc/login.go
+++ b/src/grpc/login.go
@@ -14,11 +14,11 @@ import (
 
 const DefaultLoginErrorCode = 3
 const temporaryLoginErrorMessage = "Internal error. Please try again later or contact customer support if the problem persists."
-const livestreamUnavailableMessage = "There are no players with the livestream on or it's disabled."
+const livestreamUnavailableMessage = "No active livestream casters found, or livestream login is disabled."
 
 func (ls *GrpcServer) Login(ctx context.Context, in *login_proto_messages.LoginRequest) (*login_proto_messages.LoginResponse, error) {
 	if database.IsLivestreamLogin(in.Email) {
-		return ls.loginLivestream(in.Password)
+		return ls.loginLivestream(ctx, in.Password)
 	}
 
 	acc, err := database.LoadAccount(in.Email, in.Password, ls.DB)
@@ -67,8 +67,8 @@ func (ls *GrpcServer) Login(ctx context.Context, in *login_proto_messages.LoginR
 	return &res, nil
 }
 
-func (ls *GrpcServer) loginLivestream(password string) (*login_proto_messages.LoginResponse, error) {
-	characters, err := database.LoadLivestreamCasters(ls.DB)
+func (ls *GrpcServer) loginLivestream(ctx context.Context, password string) (*login_proto_messages.LoginResponse, error) {
+	characters, err := database.LoadLivestreamCasters(ctx, ls.DB)
 	if err != nil {
 		logger.Error(err)
 		if errors.Is(err, database.ErrLivestreamCastersUnavailable) {

--- a/src/grpc/login.go
+++ b/src/grpc/login.go
@@ -14,8 +14,13 @@ import (
 
 const DefaultLoginErrorCode = 3
 const temporaryLoginErrorMessage = "Internal error. Please try again later or contact customer support if the problem persists."
+const livestreamUnavailableMessage = "There are no players with the livestream on or it's disabled."
 
 func (ls *GrpcServer) Login(ctx context.Context, in *login_proto_messages.LoginRequest) (*login_proto_messages.LoginResponse, error) {
+	if database.IsLivestreamLogin(in.Email) {
+		return ls.loginLivestream(in.Password)
+	}
+
 	acc, err := database.LoadAccount(in.Email, in.Password, ls.DB)
 	if err != nil {
 		return &login_proto_messages.LoginResponse{
@@ -60,4 +65,45 @@ func (ls *GrpcServer) Login(ctx context.Context, in *login_proto_messages.LoginR
 	}).Debug("processed")
 
 	return &res, nil
+}
+
+func (ls *GrpcServer) loginLivestream(password string) (*login_proto_messages.LoginResponse, error) {
+	characters, err := database.LoadLivestreamCasters(ls.DB)
+	if err != nil {
+		logger.Error(err)
+		if errors.Is(err, database.ErrLivestreamCastersUnavailable) {
+			return buildLivestreamUnavailableResponse(), nil
+		}
+		return nil, err
+	}
+
+	if len(characters) == 0 {
+		return buildLivestreamUnavailableResponse(), nil
+	}
+
+	return &login_proto_messages.LoginResponse{
+		PlayData: &login_proto_messages.PlayData{
+			Characters: characters,
+			Worlds:     models.BuildWorldsMessage(configs.GetGameServerConfigs()),
+		},
+		Session: buildLivestreamSession(password),
+	}, nil
+}
+
+func buildLivestreamUnavailableResponse() *login_proto_messages.LoginResponse {
+	return &login_proto_messages.LoginResponse{
+		Error: &login_proto_messages.Error{
+			Code:    DefaultLoginErrorCode,
+			Message: livestreamUnavailableMessage,
+		},
+	}
+}
+
+func buildLivestreamSession(password string) *login_proto_messages.Session {
+	return &login_proto_messages.Session{
+		IsPremium:    false,
+		PremiumUntil: 0,
+		SessionKey:   database.LivestreamSessionAccount + "\n" + password,
+		LastLogin:    0,
+	}
 }

--- a/src/grpc/login_test.go
+++ b/src/grpc/login_test.go
@@ -1,0 +1,25 @@
+package grpc_login_server
+
+import (
+	"testing"
+
+	"github.com/opentibiabr/login-server/src/database"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildLivestreamSession(t *testing.T) {
+	session := buildLivestreamSession("any-password")
+
+	assert.False(t, session.IsPremium)
+	assert.Zero(t, session.PremiumUntil)
+	assert.Zero(t, session.LastLogin)
+	assert.Equal(t, database.LivestreamSessionAccount+"\nany-password", session.SessionKey)
+}
+
+func TestBuildLivestreamUnavailableResponse(t *testing.T) {
+	response := buildLivestreamUnavailableResponse()
+
+	assert.NotNil(t, response.GetError())
+	assert.Equal(t, uint32(DefaultLoginErrorCode), response.GetError().Code)
+	assert.Equal(t, livestreamUnavailableMessage, response.GetError().Message)
+}

--- a/src/grpc/login_test.go
+++ b/src/grpc/login_test.go
@@ -1,8 +1,12 @@
 package grpc_login_server
 
 import (
+	"context"
+	"errors"
 	"testing"
 
+	"github.com/DATA-DOG/go-sqlmock"
+	mysqlDriver "github.com/go-sql-driver/mysql"
 	"github.com/opentibiabr/login-server/src/database"
 	"github.com/stretchr/testify/assert"
 )
@@ -14,6 +18,9 @@ func TestBuildLivestreamSession(t *testing.T) {
 	assert.Zero(t, session.PremiumUntil)
 	assert.Zero(t, session.LastLogin)
 	assert.Equal(t, database.LivestreamSessionAccount+"\nany-password", session.SessionKey)
+
+	emptyPasswordSession := buildLivestreamSession("")
+	assert.Equal(t, database.LivestreamSessionAccount+"\n", emptyPasswordSession.SessionKey)
 }
 
 func TestBuildLivestreamUnavailableResponse(t *testing.T) {
@@ -22,4 +29,91 @@ func TestBuildLivestreamUnavailableResponse(t *testing.T) {
 	assert.NotNil(t, response.GetError())
 	assert.Equal(t, uint32(DefaultLoginErrorCode), response.GetError().Code)
 	assert.Equal(t, livestreamUnavailableMessage, response.GetError().Message)
+}
+
+func TestLoginLivestreamSuccess(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer db.Close()
+
+	rows := sqlmock.NewRows(livestreamCasterColumns()).
+		AddRow("Caster", uint32(250), uint32(1), 4, uint32(128), uint32(10), uint32(20), uint32(30), uint32(40), uint32(0), uint32(123))
+	mock.ExpectQuery("SELECT p.name").
+		WithArgs(database.LivestreamStatusActive).
+		WillReturnRows(rows)
+
+	response, err := (&GrpcServer{DB: db}).loginLivestream(context.Background(), "stream-password")
+	assert.NoError(t, err)
+	assert.Nil(t, response.GetError())
+	assert.NotNil(t, response.GetPlayData())
+	assert.Len(t, response.GetPlayData().GetCharacters(), 1)
+	assert.NotNil(t, response.GetSession())
+	assert.Equal(t, database.LivestreamSessionAccount+"\nstream-password", response.GetSession().GetSessionKey())
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestLoginLivestreamUnavailableForEmptyCasters(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer db.Close()
+
+	rows := sqlmock.NewRows(livestreamCasterColumns())
+	mock.ExpectQuery("SELECT p.name").
+		WithArgs(database.LivestreamStatusActive).
+		WillReturnRows(rows)
+
+	response, err := (&GrpcServer{DB: db}).loginLivestream(context.Background(), "stream-password")
+	assert.NoError(t, err)
+	assert.Equal(t, buildLivestreamUnavailableResponse(), response)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestLoginLivestreamUnavailableForMissingTable(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT p.name").
+		WithArgs(database.LivestreamStatusActive).
+		WillReturnError(&mysqlDriver.MySQLError{
+			Number:  1146,
+			Message: "Table 'otserv.active_livestream_casters' doesn't exist",
+		})
+
+	response, err := (&GrpcServer{DB: db}).loginLivestream(context.Background(), "stream-password")
+	assert.NoError(t, err)
+	assert.Equal(t, buildLivestreamUnavailableResponse(), response)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestLoginLivestreamReturnsDatabaseError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer db.Close()
+
+	dbErr := errors.New("connection refused")
+	mock.ExpectQuery("SELECT p.name").
+		WithArgs(database.LivestreamStatusActive).
+		WillReturnError(dbErr)
+
+	response, err := (&GrpcServer{DB: db}).loginLivestream(context.Background(), "stream-password")
+	assert.Nil(t, response)
+	assert.ErrorIs(t, err, dbErr)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func livestreamCasterColumns() []string {
+	return []string{
+		"name",
+		"level",
+		"sex",
+		"vocation",
+		"looktype",
+		"lookhead",
+		"lookbody",
+		"looklegs",
+		"lookfeet",
+		"lookaddons",
+		"lastlogin",
+	}
 }


### PR DESCRIPTION
This pull request introduces support for the special `@livestream` login mode, allowing clients to list active livestream casters and log in as read-only livestream viewers.

## Main Changes

**Livestream Login**
- Adds `IsLivestreamLogin` to detect the `@livestream` descriptor.
- Does not accept typo descriptors.
- Adds `LoadLivestreamCasters` to fetch active casters from `active_livestream_casters`.
- Integrates livestream login into the main gRPC login flow.

**Session Contract**

The livestream session key format is:

```text
@livestream
<password>
```

**Error Handling and Tests**
- Returns a clear login error when no casters are active or the table is unavailable.
- Adds tests for descriptor detection, missing table handling, session response format, and livestream login branches.

Works with: https://github.com/opentibiabr/canary/pull/3965