### PR TITLE
fix: hash session keys with SHA-1 so the game server can find them

### DIFF
--- a/src/database/account.go
+++ b/src/database/account.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/sha1"
-	"crypto/sha256"
 	"database/sql"
 	"database/sql/driver"
 	"encoding/hex"
@@ -73,6 +72,19 @@ func (acc *Account) IsAdmin() bool {
 	return acc != nil && acc.Type >= accountTypeGameMaster
 }
 
+// hashSessionKey returns the value stored in account_sessions.id for a session
+// key.
+//
+// This must stay SHA-1. The game server looks the session up with
+// transformToSHA1(sessionKey) in account_repository_db.cpp, so any other digest
+// writes a row that is never found: the client receives the character list
+// normally and is then rejected at world login with "Your session has expired",
+// which points at expiry rather than at the hash.
+func hashSessionKey(sessionKey string) string {
+	sum := sha1.Sum([]byte(sessionKey))
+	return hex.EncodeToString(sum[:])
+}
+
 func (acc *Account) CreateSession(ctx context.Context, db *sql.DB) (string, error) {
 	if acc == nil {
 		return "", serviceerrors.LoginService(
@@ -99,7 +111,7 @@ func (acc *Account) CreateSession(ctx context.Context, db *sql.DB) (string, erro
 	}
 
 	sessionKey := hex.EncodeToString(raw)
-	hash := sha256.Sum256([]byte(sessionKey))
+	hash := hashSessionKey(sessionKey)
 	expires := time.Now().Add(sessionDuration).Unix()
 
 	if ctx == nil {
@@ -112,7 +124,7 @@ func (acc *Account) CreateSession(ctx context.Context, db *sql.DB) (string, erro
 	if _, err := db.ExecContext(
 		writeCtx,
 		"INSERT INTO `account_sessions` (`id`, `account_id`, `expires`) VALUES (?, ?, ?)",
-		fmt.Sprintf("%x", hash),
+		hash,
 		acc.ID,
 		expires,
 	); err != nil {

--- a/src/database/account_test.go
+++ b/src/database/account_test.go
@@ -181,3 +181,21 @@ func TestClassifyAuthenticationError(t *testing.T) {
 		})
 	}
 }
+
+func TestHashSessionKey(t *testing.T) {
+	// The digest is a contract with the game server, which looks the session up
+	// with transformToSHA1(sessionKey). Changing it silently breaks every world
+	// login while the HTTP login and the character list keep working, so pin it
+	// against a known SHA-1 value rather than against the implementation.
+	const sessionKey = "0123456789abcdef"
+	const wantSHA1 = "fe5567e8d769550852182cdf69d74bb16dff8e29"
+
+	got := hashSessionKey(sessionKey)
+
+	if len(got) != 40 {
+		t.Fatalf("hashSessionKey() returned %d chars, want 40 (SHA-1 hex); a 64 char digest is SHA-256 and the server will never find the row", len(got))
+	}
+	if got != wantSHA1 {
+		t.Errorf("hashSessionKey() = %q, want %q", got, wantSHA1)
+	}
+}


### PR DESCRIPTION
Session login never completes. The client authenticates, receives the character list, and is then rejected at world login with **"Your session has expired. Please log in again."** — immediately, on a session created seconds earlier.

## Cause

`CreateSession` stores SHA-256 of the session key:

```go
hash := sha256.Sum256([]byte(sessionKey))
```

The game server looks the same row up by SHA-1:

```cpp
// canary, src/account/account_repository_db.cpp
"SELECT ... FROM `accounts` "
"INNER JOIN `account_sessions` ON `account_sessions`.`account_id` = `accounts`.`id` "
"WHERE `account_sessions`.`id` = {}",
g_database().escapeString(transformToSHA1(sessionKey))
```

The row is written and never matched. The digest is a contract with the game server rather than an internal detail, and SHA-256 has been on this side since sessions were introduced in #28.

It is easy to confirm on a live database — every id is 64 characters where the server expects 40:

```
SELECT LENGTH(id), COUNT(*) FROM account_sessions GROUP BY LENGTH(id);
+------------+----------+
| LENGTH(id) | COUNT(*) |
+------------+----------+
|         64 |        3 |
+------------+----------+
```

## Why it is hard to diagnose

Two things point away from the real cause.

The game server cannot distinguish a missing session from an expired one, so it reports expiry. That sends you looking at `sessionDuration`, at clock skew between the two hosts, at the `expires` column — none of which is wrong.

And everything up to world login keeps working. The HTTP login and the character list never read `account_sessions`, so the failure appears only at the last step, after the part that would normally be blamed has already succeeded.

## Change

`hashSessionKey()` now uses SHA-1, matching what the server reads.

The digest is extracted into a named function rather than left inline, so it reads as the contract it is, and pinned with a test that checks the length before comparing the value:

```
hashSessionKey() returned 64 chars, want 40 (SHA-1 hex);
a 64 char digest is SHA-256 and the server will never find the row
```

Reverting the function to SHA-256 fails that test with exactly that message, so the next person changing it learns why it cannot move.

## Notes

Only affects deployments running the game server with `authType = "session"`. With `authType = "password"` this table is never consulted.

Sessions already stored under the old digest will not match and can be deleted; clients simply log in again:

```sql
DELETE FROM account_sessions WHERE LENGTH(id) = 64;
```

On SHA-1: the session key is 32 bytes from `crypto/rand`, and the digest exists so a database leak does not expose live tokens. That relies on preimage resistance, which SHA-1 still provides — collision resistance, the property that is broken, does not apply here. Moving both sides to SHA-256 would be a reasonable follow-up, but it has to happen in the game server first, and that server implements SHA-1 by hand with no crypto library available.

Verified against a live server: the character list loads, world login completes, and the stored id is 40 characters.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Session keys are now stored as hashed values, helping protect sensitive session data if storage is accessed.

* **Bug Fixes**
  * Improved consistency of session-key hashing and encoding during session creation.

* **Tests**
  * Added coverage verifying that session-key hashes are generated correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->